### PR TITLE
Update the spec in the islandora_defaults conflict spec.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
   },
   "conflict": {
     "drupal/core": "<=8",
-    "islandora/islandora_defaults": "<=3"
+    "islandora/islandora_defaults": "<3"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
   },
   "conflict": {
     "drupal/core": "<=8",
-    "islandora/islandora_defaults": "<=2.1.1"
+    "islandora/islandora_defaults": "<=3"
   }
 }


### PR DESCRIPTION
# What does this Pull Request do?

Bumps the version spec of the conflict, based upon bit of discussion on https://github.com/Islandora/islandora_defaults/pull/75

* **Related GitHub Issue**: (link)

* **Other Relevant Links**: (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What's new?

* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# How should this be tested?

Given a project with `islandora_defaults` of major version 2 installed, attempt to install `islandora_mirador` with this `conflict` statement.

... it should fail with something like:

```
$ composer require "islandora/islandora_mirador:dev-fix/conflict-spec as 2.x-dev"
./composer.json has been updated
Running composer update islandora/islandora_mirador --with-all-dependencies
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - islandora/islandora_defaults is locked to version 2.1.1 and an update of this package was not requested.
    - islandora/islandora_mirador dev-fix/conflict-spec conflicts with islandora/islandora_defaults <=3.
    - Root composer.json requires islandora/islandora_mirador dev-fix/conflict-spec as 2.x-dev -> satisfiable by islandora/islandora_mirador[dev-fix/conflict-spec].


Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

... independent of the `-W` flag being passed; however, requiring both should work: 

```
$ composer require "islandora/islandora_defaults:^3" "islandora/islandora_mirador:dev-fix/conflict-spec as 2.x-dev"
./composer.json has been updated
Running composer update islandora/islandora_defaults islandora/islandora_mirador
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 1 update, 0 removals
  - Upgrading islandora/islandora_defaults (2.1.1 => 3.x-dev 443fca7)
  - Locking islandora/islandora_mirador (dev-fix/conflict-spec 44f1483)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 1 update, 0 removals
  - Downloading islandora/islandora_mirador (dev-fix/conflict-spec 44f1483)
  - Downloading islandora/islandora_defaults (3.x-dev 443fca7)
  - Installing islandora/islandora_mirador (dev-fix/conflict-spec 44f1483): Extracting archive
  - Upgrading islandora/islandora_defaults (2.1.1 => 3.x-dev 443fca7): Extracting archive
Package doctrine/reflection is abandoned, you should avoid using it. Use roave/better-reflection instead.
Package silex/silex is abandoned, you should avoid using it. Use symfony/flex instead.
Package symfony/debug is abandoned, you should avoid using it. Use symfony/error-handler instead.
Generating autoload files
59 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found
```

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
