### PR TITLE
Simplify site/node-relative manifest endpoint reference.

### DIFF
--- a/config/install/islandora_mirador.settings.yml
+++ b/config/install/islandora_mirador.settings.yml
@@ -1,3 +1,3 @@
 mirador_library_installation_type: 'remote'
 mirador_enabled_plugins: {  }
-iiif_manifest_url: 'http://localhost:8000/node/[node:nid]/manifest'
+iiif_manifest_url: '[node:url:unaliased:absolute]/manifest'

--- a/src/Form/MiradorConfigForm.php
+++ b/src/Form/MiradorConfigForm.php
@@ -60,7 +60,7 @@ class MiradorConfigForm extends ConfigFormBase {
     ];
     $form['iiif_manifest_url_fieldset']['iiif_manifest_url'] = [
       '#type' => 'textfield',
-      '#description' => $this->t('Absolute URL of the IIIF manifest to render.  You may use tokens to provide a pattern (e.g. "http://localhost/node/[node:nid]/manifest")'),
+      '#description' => $this->t('Absolute URL of the IIIF manifest to render.  You may use tokens to provide a pattern (e.g. "[node:url:unaliased:absolute]/manifest" or "http://localhost/node/[node:nid]/manifest")'),
       '#default_value' => $config->get('iiif_manifest_url'),
       '#maxlength' => 256,
       '#size' => 64,


### PR DESCRIPTION
Using the provided token should avoid any issues with URL schemes or hostnames or ports and so on.

# What does this Pull Request do?

Use the built token instead of manually requiring it to be rebuilt.

* **Related GitHub Issue**: (link)

* **Other Relevant Links**: (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What's new?

Uses the `[node:url:unaliased:absolute]` to build out the base URL to the node. This token is presently provided by the "Token" module (between https://git.drupalcode.org/project/token/-/blob/8.x-1.x/token.tokens.inc#L56, https://git.drupalcode.org/project/token/-/blob/8.x-1.x/token.tokens.inc#L369-373 and https://git.drupalcode.org/project/token/-/blob/8.x-1.x/token.tokens.inc#L361-364), on which this module is already dependent (https://github.com/Islandora/islandora_mirador/blob/33843dc78790d5133735fb73f92b475bc1ee967f/islandora_mirador.info.yml#L9)

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
