### PR TITLE
Issue #23: Change default visibility of Text OVerlay text to false.

### DIFF
--- a/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
+++ b/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
@@ -23,7 +23,7 @@ class TextOverlay extends IslandoraMiradorPluginPluginBase {
     $windowConfig['textOverlay'] = [
       "enabled" => true,
       "selectable" => true,
-      "visible" => true,
+      "visible" => false,
     ];
   }
 


### PR DESCRIPTION
Issue link: https://github.com/Islandora/islandora_mirador/issues/23

# What does this Pull Request do?

Changes the default value of the Text Overlay "visible" setting to false.

# What's new?

Makes the Text Overlay plugin not display overlay rendered text while it is still selectable and visible to screen readers.
* Changes x feature to such that y

* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? No 
* Could this change impact execution of existing code? Existing sites with the Overlay enabled will see the setting change.

# How should this be tested?


Better instructions to come, will make them compatible with the starter site.

Meanwhile if tester already has a viewer set up with content that has hOCR associated with it, they can test by simply reloading a viewer after this PR is checked out, and the Text Overlay plugin is enabled.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
