### PR TITLE
Issue #27: Drupal 10 compatibility.

### DIFF
--- a/islandora_mirador.info.yml
+++ b/islandora_mirador.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Mirador'
 type: module
 description: 'Configuration for a Mirador Block'
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9.3 || ^10
 package: 'Islandora'
 dependencies:
   - drupal:block

--- a/islandora_mirador.install
+++ b/islandora_mirador.install
@@ -77,6 +77,7 @@ function _islandora_mirador_term_exists() {
   $query = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->getQuery()
     ->condition('vid', 'islandora_display')
     ->condition('field_external_uri.uri', 'https://projectmirador.org')
+    ->accessCheck(FALSE)
     ->count();
   $count = $query->execute();
   return $count > 0;


### PR DESCRIPTION
GitHub Issue: https://github.com/Islandora/islandora_mirador/issues/27

# What does this Pull Request do?


Drupal 10 compatibility fixes.
# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.


Fix errors reported by Upgrade Status module.

* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

Enable the module on a Drupal 10 site. Note that as of the creation of this PR, the [Islandora d10 compatibility fix PR](https://github.com/Islandora/islandora/pull/960) is still open so you may still need to check that branch out also. 

Go to the Islandora Mirador Administration page and ensure settings can be altered and saved.

Check  that Mirador functions as it does on an Islandora site running on Drupal 9.

# Documentation Status

* Does this change existing behaviour that's currently documented?
* Does this change require new pages or sections of documentation?
* Who does this need to be documented for?
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
