### PR TITLE
Issue #26: Fix 'Use local library' option.

### DIFF
--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -94,6 +94,7 @@ function islandora_mirador_library_info_alter(&$libraries, $extension) {
     if ($config->get('mirador_library_installation_type') == 'local') {
       unset($libraries['mirador']['remote']);
       unset($libraries['mirador']['license']);
+      unset($libraries['mirador']['js']);
       $libraries['mirador']['js']['/libraries/mirador/dist/main.js'] = [];
     }
   }

--- a/src/Form/MiradorConfigForm.php
+++ b/src/Form/MiradorConfigForm.php
@@ -2,16 +2,18 @@
 
 namespace Drupal\islandora_mirador\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\islandora_mirador\Annotation\IslandoraMiradorPlugin;
 use Drupal\islandora_mirador\IslandoraMiradorPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+
 /**
  * Mirador Settings Form.
  */
 class MiradorConfigForm extends ConfigFormBase {
+
   /**
    * @var \Drupal\islandora_mirador\IslandoraMiradorPluginManager
    */
@@ -40,6 +42,7 @@ class MiradorConfigForm extends ConfigFormBase {
         'local'=> $this->t('Local library placed in /libraries inside your webroot.'),
         'remote' => $this->t('Default remote location'),
       ],
+      '#description' => $this->t("For local, put the output of 'npm run webpack' of <a href=\"https://github.com/roblib/mirador-integration-islandora\">Mirador Integration Islandora</a> into web/library/mirador/dist/ and ensure it's named main.js."),
       '#default_value' => $config->get('mirador_library_installation_type'),
     ];
 


### PR DESCRIPTION
GitHub Issue: https://github.com/Islandora/islandora_mirador/issues/26

# What does this Pull Request do?

Fix broken option to use a local instance of [Mirador Integration Islandora](https://github.com/roblib/mirador-integration-islandora).

# What's new?

1. Add a more helpful description to the use local library option on the Islandora Mirador admin settings page.
1. Fix the library info alter hook to work correctly and not just accidentally.

* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

1. Alone the [Mirador Integration Islandora](https://github.com/roblib/mirador-integration-islandora) app.
2. Follow the instructions to compile the Webpack output.
2.1. $ npm install
2.2. $ npm run web pack 
2.3 $ cp web pack/dist/main.js [drupal root]/web/libraries/mirador/dist #create if needed
3. Go to /admin/config/media/mirador, choose 'Local' in the library location setting and save.
 4. Clear your cache and load a page with Mirador on it.
 5. In web inspector, check the Network tab for where 'main.js' is retrieved from . It should say your local site and not GitHub.
5.1. Alternatively, rename the local dist/main.js to something random, clear caches and reload. The Mirador viewer should no longer show up.

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? No
* Who does this need to be documented for? Developers
* Associated documentation pull request(s): ___  or documentation issue ___ To come.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this



# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers

@rosiel 