### PR TITLE
[DOCUMENTATION] Add migrate import instructions to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ $ composer require islandora/islandora_mirador
 $ drush en islandora_mirador
 ```
 
+
+If you wish to make use of Islandora's display hint
+system, and Mirador hasn't been set up by an installation
+stack such as ISLE or the Islandora Playbook, you will
+need to import the display hint using Drush:
+
+```bash
+drush migrate:import islandora_mirador_tags
+```
+
 ### Upgrading from Islandora Defaults
 
 This module was formerly distributed with Islandora Defaults. If you are upgrading


### PR DESCRIPTION
# What does this Pull Request do?

Adds a line to the README about importing the display hint using Drush Migrate in case the module is installed outside of ISLE or Playbook.