### PR TITLE
Require Islandora using its drupal namespace.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "issues": "https://github.com/Islandora/documentation/issues"
   },
   "require": {
-    "islandora/islandora": "^2"
+    "drupal/islandora": "^2"
   },
   "conflict": {
     "drupal/core": "<=8",


### PR DESCRIPTION
# What does this Pull Request do?

Solves the duplicate namespace problem encountered when Islandora Starter Site requires drupal/islandora but this repo requires islandora/islandora

* **Related GitHub Issue**: n/a

* **Other Relevant Links**: https://github.com/Islandora-Devops/islandora-starter-site/pull/113

# What's new?

Changes namespace of required islandora module from islandora to drupal.

# How should this be tested?

Load the Starter site. Use `composer show` to see that you have both `islandora/islandora_mirador` and `drupal/islandora_mirador` competing to write code to the same folder.

When requiring this version of Mirador, you should no longer have islandora/islandora but instead only drupal/islandora.

# Documentation Status

* Does this change existing behaviour that's currently documented? no
* Does this change require new pages or sections of documentation? no
* Who does this need to be documented for? no
* Associated documentation pull request(s): ___  or documentation issue ___

# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag @alxp 