### PR TITLE
39-embiggen Make viewer be 1200 pixels high by default.

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -1,4 +1,4 @@
 .block-mirador {
-  height: 500px;
+  height: 1200px;
   position: relative;
 }


### PR DESCRIPTION
# What does this Pull Request do?


Change the CSS so the viewer is 1200px high rather than 500.

* **Related GitHub Issue**: [link](https://github.com/Islandora/islandora_mirador/issues/39)

# What's new?
A in-depth description of the changes made by this PR. Technical details and
 possible side effects.

The CSS for teh Mirador block's height attribute changed from 500 to 1200

* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

On a site that does not have a custom theme overriding the styling of a Mirador block, load the viewer after clearing Drupal's cache. You may need to try opening in a private window to load the latest CSS.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
