### PR TITLE
#41 theme variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,56 @@ Configure contexts at "Administration » Structure » Context".
 As noted previously, this is just one way to set up the Mirador viewer configurations. If, for example, you wanted to always use the Mirador viewer for pages and paged content, you could remove the "Mirador" condition from the "Node has term" condition in these contexts.
 
 
+## Theme Variables
+
+Mirador's appearance and behaviour is configured via settings passed
+to the JavaScript application. Mainly in 'window' and 'workspace' configuration
+array.
+
+These can be specified via theme variables or by passing
+them as arguments instantiating the Mirador block class.
+
+To hide the close button via a theme hook:
+
+```php
+function mymodule_preprocess_mirador(&$variables) {
+  $variables['window_config']['allowClose'] = FALSE;
+}
+```
+
+To make a minimal UI by instantiating the block:
+
+```php
+      $block = \Drupal::service('plugin.manager.block')->createInstance($viewer . '_block', [
+        'iiif_manifest_url' => "/node/$manifest_nid/manifest-single",
+        'thumbnail_navigation_position' => 'hidden',
+        'window_config' => [
+          'allowClose' => FALSE,
+          'allowMaximize' => FALSE,
+          'allowTopMenuButton' => FALSE,
+          'allowWindowSideBar' => FALSE,
+          'hideWindowTitle' => TRUE,
+          'panels' => [
+            'info' => FALSE,
+            'attribution' => FALSE,
+            '	  canvas' => FALSE,
+            'annotations' => FALSE,
+            'search' => FALSE,
+          ],
+        ],
+        'workspace_config' => [
+          'allowNewWindows' => FALSE,
+          'isWorkspaceAddVisible' => FALSE,
+          'workspaceControlPanel' => [
+            'enable' => FALSE,
+          ],
+
+        ],
+      ]);
+
+```
+
+See the Mirador FAQ for more options: https://github.com/ProjectMirador/mirador/wiki/M3---Mirador-3-Frequently-Asked-Questions
 
 ## Documentation
 

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -20,6 +20,7 @@ function islandora_mirador_theme() {
       'variables' => [
         'iiif_manifest_url' => NULL,
         'mirador_view_id' => NULL,
+        'thumbnail_navigation_position' => 'far-bottom',
       ],
       'template' => 'mirador',
     ],
@@ -78,7 +79,7 @@ function template_preprocess_mirador(&$variables) {
     'windows' => [
       [
         'manifestId' => $variables['iiif_manifest_url'],
-        'thumbnailNavigationPosition' => 'far-bottom',
+        'thumbnailNavigationPosition' => $variables['thumbnail_navigation_position'],
       ],
     ]
   ];

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -22,6 +22,7 @@ function islandora_mirador_theme() {
         'mirador_view_id' => NULL,
         'thumbnail_navigation_position' => 'far-bottom',
         'window_config' => [],
+        'workspace_config' => [],
       ],
       'template' => 'mirador',
     ],
@@ -59,8 +60,6 @@ function template_preprocess_mirador(&$variables) {
     }
   }
 
-
-
   // XXX: Maintain the original properties, for now.
   $variables['#attached']['drupalSettings']['mirador_view_id'] = $variables['mirador_view_id'];
   $variables['#attached']['drupalSettings']['mirador_window_settings'] = $window_config;
@@ -84,7 +83,8 @@ function template_preprocess_mirador(&$variables) {
         'manifestId' => $variables['iiif_manifest_url'],
         'thumbnailNavigationPosition' => $variables['thumbnail_navigation_position'],
       ],
-    ]
+    ],
+    'workspace' => $variables['workspace_config'],
   ];
 }
 

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -21,6 +21,7 @@ function islandora_mirador_theme() {
         'iiif_manifest_url' => NULL,
         'mirador_view_id' => NULL,
         'thumbnail_navigation_position' => 'far-bottom',
+        'window_config' => [],
       ],
       'template' => 'mirador',
     ],
@@ -47,7 +48,7 @@ function template_preprocess_mirador(&$variables) {
   $enabled_plugins = $config->get('mirador_enabled_plugins');
   $variables['#attached']['drupalSettings']['mirador']['enabled_plugins'] = array_filter(array_values($enabled_plugins));
 
-  $window_config = [];
+  $window_config = $variables['window_config'];
   foreach ($mirador_plugins as $plugin_id => $plugin_definition) {
     if ($enabled_plugins[$plugin_id]) {
       $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
@@ -57,6 +58,8 @@ function template_preprocess_mirador(&$variables) {
       $plugin_instance->windowConfigAlter($window_config);
     }
   }
+
+
 
   // XXX: Maintain the original properties, for now.
   $variables['#attached']['drupalSettings']['mirador_view_id'] = $variables['mirador_view_id'];

--- a/src/Plugin/Block/MiradorBlock.php
+++ b/src/Plugin/Block/MiradorBlock.php
@@ -124,6 +124,7 @@ class MiradorBlock extends BlockBase implements ContainerFactoryPluginInterface 
     }
     if (!empty($this->configuration['window_config'])) {
       $build['viewer']['#window_config'] = $this->configuration['window_config'];
+      $build['viewer']['#workspace_config'] = $this->configuration['workspace_config'];
     }
     return $build;
   }

--- a/src/Plugin/Block/MiradorBlock.php
+++ b/src/Plugin/Block/MiradorBlock.php
@@ -122,6 +122,9 @@ class MiradorBlock extends BlockBase implements ContainerFactoryPluginInterface 
     if (!empty($this->configuration['thumbnail_navigation_position'])) {
       $build['viewer']['#thumbnail_navigation_position'] = $this->configuration['thumbnail_navigation_position'];
     }
+    if (!empty($this->configuration['window_config'])) {
+      $build['viewer']['#window_config'] = $this->configuration['window_config'];
+    }
     return $build;
   }
 

--- a/src/Plugin/Block/MiradorBlock.php
+++ b/src/Plugin/Block/MiradorBlock.php
@@ -119,6 +119,9 @@ class MiradorBlock extends BlockBase implements ContainerFactoryPluginInterface 
       ],
     ];
 
+    if (!empty($this->configuration['thumbnail_navigation_position'])) {
+      $build['viewer']['#thumbnail_navigation_position'] = $this->configuration['thumbnail_navigation_position'];
+    }
     return $build;
   }
 


### PR DESCRIPTION
# What does this Pull Request do?
* **Related GitHub Issue**:  #41 
# What's new?

This change adds three new theme variables, and hooks them up to the block class configuration.

- window_config
- - workspace_config
- - thumbnail_navigation_position
The first two are arrays and can pass along any configs to the Mirador instantiation JS code to, e.g., remove unwanted UI elements.



* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)?  No
* Could this change impact execution of existing code? No

# How should this be tested?

After clearing cache, this can be tested by implementing the example hook or block instantiation from the updated README and verifying that Mirador's appearance changes accordingly.

# Documentation Status

* Does this change existing behaviour that's currently documented? No
* Does this change require new pages or sections of documentation? README updated.
* Who does this need to be documented for? Developers.



# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
