### PR TITLE
#43 Add isset() to prevent PHP warning when no plugins enabled

### DIFF
--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -51,7 +51,7 @@ function template_preprocess_mirador(&$variables) {
 
   $window_config = $variables['window_config'];
   foreach ($mirador_plugins as $plugin_id => $plugin_definition) {
-    if ($enabled_plugins[$plugin_id]) {
+    if (isset($enabled_plugins[$plugin_id])) {
       $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
       /**
        * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface


### PR DESCRIPTION
# What does this Pull Request do?

Add isset() to prevent PHP Warning.

* **Related GitHub Issue**: (link)
* https://github.com/Islandora/islandora_mirador/issues/43

# How should this be tested?

1. When no plugins enabled, observe PHP warnings when viewing Mirador block.
2. Apply PR / patch.
3. Observe no PHP warning when viewing Mirador block. 

# Interested parties
@elizoller @alxp 
