### PR TITLE
downgrade 0.1.1 to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ a Plugin Not Found error.
 The module can use either an instance of Mirador Integration hosted
 on the web, or deployed locally.
 
-Islandora maintains a version of the Mirador library that includes image manipulation and text overlay plugins. This compiled library is available on the web at https://islandora.github.io/mirador-integration-islandora/islandora-mirador-0.1.1.js, and the github project is at https://github.com/islandora/mirador-integration-islandora.
+Islandora maintains a version of the Mirador library that includes image manipulation and text overlay plugins. This compiled library is available on the web at https://islandora.github.io/mirador-integration-islandora/islandora-mirador-0.1.0.js, and the github project is at https://github.com/islandora/mirador-integration-islandora.
 
 If you have a local build, put it in
 your webroot at libraries/mirador/dist/main.js.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ a Plugin Not Found error.
 The module can use either an instance of Mirador Integration hosted
 on the web, or deployed locally.
 
-Islandora maintains a version of the Mirador library that includes image manipulation and text overlay plugins. This compiled library is available on the web at https://islandora.github.io/mirador-integration-islandora/islandora-mirador-0.1.0.js, and the github project is at https://github.com/islandora/mirador-integration-islandora.
+Islandora maintains a version of the Mirador library that includes image manipulation and text overlay plugins. This compiled library is available on the web at https://islandora.github.io/mirador-integration-islandora/islandora-mirador-0.1.1.js, and the github project is at https://github.com/islandora/mirador-integration-islandora.
 
 If you have a local build, put it in
 your webroot at libraries/mirador/dist/main.js.
@@ -208,7 +208,7 @@ See the Mirador FAQ for more options: https://github.com/ProjectMirador/mirador/
 
 ## Documentation
 
-Further documentation for IIIF (International Image Interoperability Framework) is available on the [Islandora 8 documentation site](https://islandora.github.io/documentation/user-documentation/iiif/).
+Further documentation for IIIF (International Image Interoperability Framework) is available on the [Islandora documentation site](https://islandora.github.io/documentation/user-documentation/iiif/).
 
 ## Troubleshooting/Issues
 

--- a/islandora_mirador.libraries.yml
+++ b/islandora_mirador.libraries.yml
@@ -6,12 +6,12 @@ mirador:
     url: https://github.com/ProjectMirador/mirador/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdn.jsdelivr.net/gh/islandora/mirador-integration-islandora@gh-pages/islandora-mirador-0.1.0.js:
+    https://cdn.jsdelivr.net/gh/islandora/mirador-integration-islandora@gh-pages/islandora-mirador-0.1.1.js:
       type: external
       minified: true
       attributes:
         # Calculated with/adapted from https://www.srihash.org/
-        integrity: sha384-xkwTEkgf5HcEc1ycL7NpyxdRs+8LnO+pdmFwJCY6Z+uBDM6pLeWTeO7n+NesgidO
+        integrity: sha384-H5YQxUhUbKfpBiKCSX4CVhogXKAWLM31Wj3STZe4TIhc4F1DzfOpGJUo8Qav7eoa
         crossorigin: anonymous
 viewer:
   version: 1.x

--- a/islandora_mirador.libraries.yml
+++ b/islandora_mirador.libraries.yml
@@ -6,7 +6,7 @@ mirador:
     url: https://github.com/ProjectMirador/mirador/blob/master/LICENSE
     gpl-compatible: true
   js:
-    https://cdn.jsdelivr.net/gh/islandora/mirador-integration-islandora@gh-pages/islandora-mirador-0.1.1.js:
+    https://cdn.jsdelivr.net/gh/islandora/mirador-integration-islandora@gh-pages/islandora-mirador-0.1.0.js:
       type: external
       minified: true
       attributes:


### PR DESCRIPTION
# What does this Pull Request do?
mirador integration 0.1.1 breaks things.
0.1.0 still works.
