### PR TITLE
Implemented a solution to the issue with the state of the text overlay checkbox in the mirador settings not affecting the presence of the text overlay

### DIFF
--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -46,19 +46,29 @@ function template_preprocess_mirador(&$variables) {
   $config = \Drupal::service('config.factory')
     ->get('islandora_mirador.settings');
 
+  // Add config as cache dependency so changes invalidate the render cache.
+  $variables['#cache']['tags'][] = 'config:islandora_mirador.settings';
+
   $mirador_plugins = $mirador_plugin_manager->getDefinitions();
   $enabled_plugins = $config->get('mirador_enabled_plugins');
   $variables['#attached']['drupalSettings']['mirador']['enabled_plugins'] = array_filter(array_values($enabled_plugins));
 
   $window_config = $variables['window_config'];
   foreach ($mirador_plugins as $plugin_id => $plugin_definition) {
-    if (isset($enabled_plugins[$plugin_id])) {
-      $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
-      /**
-       * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
-       */
-      $plugin_instance->windowConfigAlter($window_config);
-    }
+    // if (isset($enabled_plugins[$plugin_id])) {
+    //   $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
+    //   /**
+    //    * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
+    //    */
+    //   $plugin_instance->windowConfigAlter($window_config);
+    // }
+
+    // Always call plugins - they will check their own state
+    $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
+    /**
+     * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
+     */
+    $plugin_instance->windowConfigAlter($window_config);
   }
 
   // XXX: Maintain the original properties, for now.

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -55,19 +55,12 @@ function template_preprocess_mirador(&$variables) {
 
   $window_config = $variables['window_config'];
   foreach ($mirador_plugins as $plugin_id => $plugin_definition) {
-    // if (isset($enabled_plugins[$plugin_id])) {
-    //   $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
-    //   /**
-    //    * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
-    //    */
-    //   $plugin_instance->windowConfigAlter($window_config);
-    // }
 
     // Always call plugins - they will check their own state
-    $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
     /**
      * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
      */
+    $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
     $plugin_instance->windowConfigAlter($window_config);
   }
 

--- a/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
+++ b/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
@@ -20,8 +20,20 @@ class MiradorImageTools extends IslandoraMiradorPluginPluginBase {
    * {@InheritDoc}
    */
   public function windowConfigAlter(array &$windowConfig) {
-    $windowConfig['imageToolsEnabled'] = true;
-    $windowConfig['imageToolsOpen'] = true;
+    // Get the config to check if this plugin is enabled.
+    $config = \Drupal::service('config.factory')
+      ->get('islandora_mirador.settings');
+    $enabled_plugins = $config->get('mirador_enabled_plugins');
+    
+    if (!empty($enabled_plugins['miradorImageToolsPlugin'])) {
+      // Enabled config - checkbox is checked.
+      $windowConfig['imageToolsEnabled'] = true;
+      $windowConfig['imageToolsOpen'] = true;
+    } else {
+      // Disabled config - checkbox is unchecked.
+      $windowConfig['imageToolsEnabled'] = false;
+      $windowConfig['imageToolsOpen'] = false;
+    }
   }
 
 }

--- a/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
+++ b/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
@@ -20,11 +20,26 @@ class TextOverlay extends IslandoraMiradorPluginPluginBase {
    * {@InheritDoc}
    */
   public function windowConfigAlter(array &$windowConfig) {
-    $windowConfig['textOverlay'] = [
-      "enabled" => true,
-      "selectable" => true,
-      "visible" => false,
-    ];
+    // Get the config to check if this plugin is enabled.
+    $config = \Drupal::service('config.factory')
+      ->get('islandora_mirador.settings');
+    $enabled_plugins = $config->get('mirador_enabled_plugins');
+    
+    if (!empty($enabled_plugins['textOverlayPlugin'])) {
+      // Enabled config - checkbox is checked.
+      $windowConfig['textOverlay'] = [
+        "enabled" => true,
+        "selectable" => true,
+        "visible" => false,
+      ];
+    } else {
+      // Disabled config - checkbox is unchecked.
+      $windowConfig['textOverlay'] = [
+        "enabled" => false,
+        "selectable" => false,
+        "visible" => false,
+      ];
+    }
   }
 
 }


### PR DESCRIPTION

# What does this Pull Request do?

It lets the state of the "Text Overlay" checkbox in the mirador settings, affect whether or not the text overlay is enabled.

* **Related GitHub Issue**: (link)

This is the link to the issue on Github:
https://github.com/Islandora/islandora_mirador/issues/59

# What's new?
An in-depth description of the changes made by this PR. Technical details and
 possible side effects.

- Changed TextOverlay.php - plugins now check their own checkbox state and provide enabled/disabled configuration accordingly
- Changed islandora_miradora.module - removed conditional plugin loading, now always calls all plugins (they decide internally what config to provide)
- Added cache invalidation tag so configuration changes take effect immediately without manual cache clearing
- This does not add any dependencies
- This will not affect existing code outside of the presence of the text overlay being dependent on the state of the "Text Overlay" checkbox in the mirador settings, in configuration

# How should this be tested?

A description of what steps someone could take to:
* Before applying the changes, to reproduce the issue, you can uncheck the "Text Overlay" checkbox and see if the text overlay is present, and then check the "Text Overlay" checkbox and then observe the text overlay's presence, and you will find (from our testing) that the text overlay's presence is not affected by the state of the checkbox, and is tied to the hardcoded code in TextOverlay.php
* Similar to trying to reproduce the issue, apply the changes, then uncheck the "Text Overlay" checkbox, save the configuration, and then check if the text overlay is absent (it should be absent), and then check the "Text Overlay" checkbox, save the configuration and then check if the text overlay is present (it should be present). 

# Documentation Status

* This changes fix the state of the site and code so that it works as intended, as before it was not working how it was supposed to.

# Additional Notes:
None

# Interested parties
@digitalutsc
