### PR TITLE
Fix config form for Drupal 11, lint codebase, add lint/test to CI

### DIFF
--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [ 2.x ]
+  pull_request:
+    branches: [ 2.x ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ["8.3", "8.4"]
+        drupal-version: ["10.5", "10.6", "11.2", "11.3"]
+    name: PHP ${{ matrix.php-versions }} | drupal ${{ matrix.drupal-version }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: create docker network
+        run: docker network create ci-default
+
+      - name: PHPUNIT tests
+        run: |
+          docker run \
+            --rm \
+            --name drupal \
+            --hostname drupal \
+            --volume $(pwd):/var/www/drupal/web/modules/contrib/$ENABLE_MODULES:ro \
+            --env ENABLE_MODULES \
+            --network ci-default \
+           ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
+        env:
+          ENABLE_MODULES: advanced_search

--- a/.github/workflows/build-2.x.yml
+++ b/.github/workflows/build-2.x.yml
@@ -38,4 +38,4 @@ jobs:
             --network ci-default \
            ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
         env:
-          ENABLE_MODULES: advanced_search
+          ENABLE_MODULES: islandora_mirador

--- a/islandora_mirador.info.yml
+++ b/islandora_mirador.info.yml
@@ -1,7 +1,7 @@
 name: 'Islandora Mirador'
 type: module
 description: 'Configuration for a Mirador Block'
-core_version_requirement: ^9.3 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 package: 'Islandora'
 dependencies:
   - drupal:block

--- a/islandora_mirador.install
+++ b/islandora_mirador.install
@@ -39,7 +39,7 @@ function islandora_mirador_requirements($phase) : array {
 }
 
 /**
- * Implements hook_update_last_removed.
+ * Implements hook_update_last_removed().
  */
 function islandora_mirador_update_last_removed() {
   return 8001;
@@ -47,8 +47,6 @@ function islandora_mirador_update_last_removed() {
 
 /**
  * Set a default config value for mirador_library_installation_type.
- *
- * @return void
  */
 function islandora_mirador_update_20001() {
   $config = \Drupal::configFactory()->getEditable('islandora_mirador.settings');

--- a/islandora_mirador.install
+++ b/islandora_mirador.install
@@ -5,8 +5,6 @@
  * Install/update hook implementations.
  */
 
-use Drupal\taxonomy\Entity\Term;
-
 /**
  * Implements hook_install().
  */
@@ -33,7 +31,7 @@ function islandora_mirador_requirements($phase) : array {
       'title' => t('Mirador Term Exists'),
       'value' => $term_exists ? t('Exists') : t('Does not exist'),
       'description' => t('Whether or not a term with the URI targeted by default Mirador viewer configuration exists. If viewer configurations were made to target another URI, this can probably be ignored.'),
-      'severity' => $term_exists ? REQUIREMENT_OK : REQUIREMENT_WARNING
+      'severity' => $term_exists ? REQUIREMENT_OK : REQUIREMENT_WARNING,
     ];
   }
 
@@ -48,13 +46,14 @@ function islandora_mirador_update_last_removed() {
 }
 
 /**
- * Set a default config value for mirador_library_installation_type
+ * Set a default config value for mirador_library_installation_type.
+ *
  * @return void
  */
 function islandora_mirador_update_20001() {
-$config = \Drupal::configFactory()->getEditable('islandora_mirador.settings');
+  $config = \Drupal::configFactory()->getEditable('islandora_mirador.settings');
   $config->set('mirador_library_installation_type', 'remote');
-    $config->save();
+  $config->save();
 }
 
 /**

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -6,10 +6,6 @@
  */
 
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Config\ImmutableConfig;
-
-use Drupal\islandora_mirador\IslandoraMiradorPluginPluginBase;
-use Drupal\islandora_mirador\IslandoraMiradorPluginInterface;
 
 /**
  * Implements hook_theme().

--- a/src/Form/MiradorConfigForm.php
+++ b/src/Form/MiradorConfigForm.php
@@ -6,7 +6,6 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\islandora_mirador\Annotation\IslandoraMiradorPlugin;
 use Drupal\islandora_mirador\IslandoraMiradorPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -41,7 +40,7 @@ class MiradorConfigForm extends ConfigFormBase {
       '#type' => 'radios',
       '#options' => [
         'remote' => $this->t('Default remote location'),
-        'local'=> $this->t('Local library placed in /libraries inside your webroot.'),
+        'local' => $this->t('Local library placed in /libraries inside your webroot.'),
 
       ],
       '#description' => $this->t("For local, put the output of 'npm run webpack' of <a href=\"https://github.com/islandora/mirador-integration-islandora\">Mirador Integration Islandora</a> into web/library/mirador/dist/ and ensure it's named main.js."),
@@ -69,7 +68,7 @@ class MiradorConfigForm extends ConfigFormBase {
       '#description' => $this->t('Which plugins to enable. The plugins must be compiled in to the application. See the documentation for instructions.'),
       '#type' => 'checkboxes',
       '#options' => $plugins,
-      '#default_value' =>  $config->get('mirador_enabled_plugins'),
+      '#default_value' => $config->get('mirador_enabled_plugins'),
     ];
     $form['iiif_manifest_url_fieldset'] = [
       '#type' => 'fieldset',
@@ -119,17 +118,18 @@ class MiradorConfigForm extends ConfigFormBase {
   /**
    * Constructs the Mirador config form.
    *
-   * @param ConfigFactoryInterface $config_factory
-   * The configuration factory.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
    * @param \Drupal\Core\Config\TypedConfigManagerInterface $typed_config_manager
    *   The typed config manager.
-   * @param IslandoraMiradorPluginManager $mirador_plugin_manager
-   * The Mirador Plugin Manager interface.
+   * @param \Drupal\islandora_mirador\Annotation\IslandoraMiradorPluginManager $mirador_plugin_manager
+   *   The Mirador Plugin Manager interface.
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
     TypedConfigManagerInterface $typed_config_manager,
-    IslandoraMiradorPluginManager $mirador_plugin_manager) {
+    IslandoraMiradorPluginManager $mirador_plugin_manager,
+  ) {
     parent::__construct($config_factory, $typed_config_manager);
     $this->miradorPluginManager = $mirador_plugin_manager;
   }

--- a/src/Form/MiradorConfigForm.php
+++ b/src/Form/MiradorConfigForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\islandora_mirador\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\islandora_mirador\Annotation\IslandoraMiradorPlugin;
@@ -120,11 +121,16 @@ class MiradorConfigForm extends ConfigFormBase {
    *
    * @param ConfigFactoryInterface $config_factory
    * The configuration factory.
+   * @param \Drupal\Core\Config\TypedConfigManagerInterface $typed_config_manager
+   *   The typed config manager.
    * @param IslandoraMiradorPluginManager $mirador_plugin_manager
    * The Mirador Plugin Manager interface.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, IslandoraMiradorPluginManager $mirador_plugin_manager) {
-    parent::__construct($config_factory);
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    TypedConfigManagerInterface $typed_config_manager,
+    IslandoraMiradorPluginManager $mirador_plugin_manager) {
+    parent::__construct($config_factory, $typed_config_manager);
     $this->miradorPluginManager = $mirador_plugin_manager;
   }
 
@@ -134,6 +140,7 @@ class MiradorConfigForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
+      $container->get('config.typed'),
       $container->get('plugin.manager.islandora_mirador')
     );
   }

--- a/src/Form/MiradorConfigForm.php
+++ b/src/Form/MiradorConfigForm.php
@@ -15,6 +15,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class MiradorConfigForm extends ConfigFormBase {
 
   /**
+   * The Mirador plugin manager.
+   *
    * @var \Drupal\islandora_mirador\IslandoraMiradorPluginManager
    */
   protected $miradorPluginManager;

--- a/src/IslandoraMiradorPluginInterface.php
+++ b/src/IslandoraMiradorPluginInterface.php
@@ -20,6 +20,7 @@ interface IslandoraMiradorPluginInterface {
    * Mirador window JSON array.
    *
    * @param array $windowConfig
+   *
    * @return void
    */
   public function windowConfigAlter(array &$windowConfig);

--- a/src/IslandoraMiradorPluginInterface.php
+++ b/src/IslandoraMiradorPluginInterface.php
@@ -16,12 +16,13 @@ interface IslandoraMiradorPluginInterface {
   public function label();
 
   /**
-   * Lets a plugin inject custom settings into the
-   * Mirador window JSON array.
+   * Lets a plugin inject custom settings into the Mirador window JSON array.
    *
    * @param array $windowConfig
+   *   The window configuration array to alter.
    *
    * @return void
+   *   Returns nothing.
    */
   public function windowConfigAlter(array &$windowConfig);
 

--- a/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
+++ b/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
@@ -16,7 +16,7 @@ use Drupal\islandora_mirador\IslandoraMiradorPluginPluginBase;
 class MiradorImageTools extends IslandoraMiradorPluginPluginBase {
 
   /**
-   * {@InheritDoc}
+   * {@inheritdoc}
    */
   public function windowConfigAlter(array &$windowConfig) {
     $windowConfig['imageToolsEnabled'] = TRUE;

--- a/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
+++ b/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
@@ -3,7 +3,6 @@
 namespace Drupal\islandora_mirador\Plugin\IslandoraMiradorPlugin;
 
 use Drupal\islandora_mirador\IslandoraMiradorPluginPluginBase;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of the islandora_mirador.
@@ -20,8 +19,8 @@ class MiradorImageTools extends IslandoraMiradorPluginPluginBase {
    * {@InheritDoc}
    */
   public function windowConfigAlter(array &$windowConfig) {
-    $windowConfig['imageToolsEnabled'] = true;
-    $windowConfig['imageToolsOpen'] = true;
+    $windowConfig['imageToolsEnabled'] = TRUE;
+    $windowConfig['imageToolsOpen'] = TRUE;
   }
 
 }

--- a/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
+++ b/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
@@ -16,7 +16,7 @@ use Drupal\islandora_mirador\IslandoraMiradorPluginPluginBase;
 class TextOverlay extends IslandoraMiradorPluginPluginBase {
 
   /**
-   * {@InheritDoc}
+   * {@inheritdoc}
    */
   public function windowConfigAlter(array &$windowConfig) {
     $windowConfig['textOverlay'] = [

--- a/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
+++ b/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
@@ -3,7 +3,6 @@
 namespace Drupal\islandora_mirador\Plugin\IslandoraMiradorPlugin;
 
 use Drupal\islandora_mirador\IslandoraMiradorPluginPluginBase;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Plugin implementation of the islandora_mirador.
@@ -21,9 +20,9 @@ class TextOverlay extends IslandoraMiradorPluginPluginBase {
    */
   public function windowConfigAlter(array &$windowConfig) {
     $windowConfig['textOverlay'] = [
-      "enabled" => true,
-      "selectable" => true,
-      "visible" => false,
+      "enabled" => TRUE,
+      "selectable" => TRUE,
+      "visible" => FALSE,
     ];
   }
 

--- a/tests/src/Kernel/IslandoraMiradorPluginManagerTest.php
+++ b/tests/src/Kernel/IslandoraMiradorPluginManagerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\Tests\islandora_mirador\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\islandora_mirador\IslandoraMiradorPluginInterface;
+
+/**
+ * Tests the Islandora Mirador plugin manager.
+ *
+ * @group islandora_mirador
+ */
+class IslandoraMiradorPluginManagerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'islandora_mirador',
+  ];
+
+  /**
+   * The plugin manager.
+   *
+   * @var \Drupal\islandora_mirador\IslandoraMiradorPluginManager
+   */
+  protected $pluginManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->pluginManager = $this->container->get('plugin.manager.islandora_mirador');
+  }
+
+  /**
+   * Tests that the plugin manager discovers all plugins.
+   */
+  public function testPluginDiscovery(): void {
+    $definitions = $this->pluginManager->getDefinitions();
+
+    $this->assertArrayHasKey('textOverlayPlugin', $definitions);
+    $this->assertArrayHasKey('miradorImageToolsPlugin', $definitions);
+    $this->assertCount(2, $definitions);
+  }
+
+  /**
+   * Tests that plugin definitions contain required properties.
+   */
+  public function testPluginDefinitions(): void {
+    $definitions = $this->pluginManager->getDefinitions();
+
+    foreach ($definitions as $plugin_id => $definition) {
+      $this->assertArrayHasKey('id', $definition, "Plugin $plugin_id missing 'id' property");
+      $this->assertArrayHasKey('label', $definition, "Plugin $plugin_id missing 'label' property");
+      $this->assertArrayHasKey('description', $definition, "Plugin $plugin_id missing 'description' property");
+    }
+
+    // Check specific labels.
+    $this->assertEquals('Text Overlay', (string) $definitions['textOverlayPlugin']['label']);
+    $this->assertEquals('Mirador Image Tools', (string) $definitions['miradorImageToolsPlugin']['label']);
+  }
+
+  /**
+   * Tests that plugins can be instantiated.
+   */
+  public function testPluginInstantiation(): void {
+    $text_overlay = $this->pluginManager->createInstance('textOverlayPlugin');
+    $this->assertInstanceOf(IslandoraMiradorPluginInterface::class, $text_overlay);
+
+    $image_tools = $this->pluginManager->createInstance('miradorImageToolsPlugin');
+    $this->assertInstanceOf(IslandoraMiradorPluginInterface::class, $image_tools);
+  }
+
+  /**
+   * Tests the plugin label() method.
+   */
+  public function testPluginLabel(): void {
+    $text_overlay = $this->pluginManager->createInstance('textOverlayPlugin');
+    $this->assertEquals('Text Overlay', $text_overlay->label());
+
+    $image_tools = $this->pluginManager->createInstance('miradorImageToolsPlugin');
+    $this->assertEquals('Mirador Image Tools', $image_tools->label());
+  }
+
+  /**
+   * Tests the TextOverlay plugin windowConfigAlter() method.
+   */
+  public function testTextOverlayWindowConfigAlter(): void {
+    $plugin = $this->pluginManager->createInstance('textOverlayPlugin');
+    $window_config = [];
+
+    $plugin->windowConfigAlter($window_config);
+
+    $this->assertArrayHasKey('textOverlay', $window_config);
+    $this->assertTrue($window_config['textOverlay']['enabled']);
+    $this->assertTrue($window_config['textOverlay']['selectable']);
+    $this->assertFalse($window_config['textOverlay']['visible']);
+  }
+
+  /**
+   * Tests the MiradorImageTools plugin windowConfigAlter() method.
+   */
+  public function testMiradorImageToolsWindowConfigAlter(): void {
+    $plugin = $this->pluginManager->createInstance('miradorImageToolsPlugin');
+    $window_config = [];
+
+    $plugin->windowConfigAlter($window_config);
+
+    $this->assertArrayHasKey('imageToolsEnabled', $window_config);
+    $this->assertArrayHasKey('imageToolsOpen', $window_config);
+    $this->assertTrue($window_config['imageToolsEnabled']);
+    $this->assertTrue($window_config['imageToolsOpen']);
+  }
+
+  /**
+   * Tests that multiple plugins can alter the same config array.
+   */
+  public function testMultiplePluginsAlterConfig(): void {
+    $window_config = [];
+
+    foreach ($this->pluginManager->getDefinitions() as $plugin_id => $definition) {
+      $plugin = $this->pluginManager->createInstance($plugin_id);
+      $plugin->windowConfigAlter($window_config);
+    }
+
+    // Verify both plugins contributed their settings.
+    $this->assertArrayHasKey('textOverlay', $window_config);
+    $this->assertArrayHasKey('imageToolsEnabled', $window_config);
+    $this->assertArrayHasKey('imageToolsOpen', $window_config);
+  }
+
+}


### PR DESCRIPTION
Drupal 11's `ConfigFormBase::_construct` requires a second parameter: https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Form%21ConfigFormBase.php/function/ConfigFormBase%3A%3A__construct/11.x

Since Drupal 9 doesn't have this second parameter defined, dropped it from info.yml

Without this code change, in Drupal 11 when viewing `/admin/config/media/mirador` an error is thrown

```
TypeError: Drupal\Core\Form\ConfigFormBase::__construct(): Argument #2 ($typedConfigManager) must be of type Drupal\Core\Config\TypedConfigManagerInterface, null given, called in /var/www/drupal/web/modules/contrib/islandora_mirador/src/Form/MiradorConfigForm.php on line 127 in Drupal\Core\Form\ConfigFormBase->__construct() (line 44 of /var/www/drupal/web/core/lib/Drupal/Core/Form/ConfigFormBase.php).
```
# Additional Notes:
Any additional information that you think would be helpful when reviewing this
 PR.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
