### PR TITLE
Continuation of #60: Fix Text Overlay configuration using Dependency Injection

### DIFF
--- a/config/install/islandora_mirador.settings.yml
+++ b/config/install/islandora_mirador.settings.yml
@@ -1,6 +1,6 @@
 mirador_library_installation_type: 'remote'
 mirador_enabled_plugins: 
-  - miradorImageToolsPlugin
-  - textOverlayPlugin
+  miradorImageToolsPlugin: miradorImageToolsPlugin
+  textOverlayPlugin: textOverlayPlugin
 iiif_manifest_url: '[node:url:unaliased:absolute]/manifest'
 mirador_library_minified: false

--- a/config/install/islandora_mirador.settings.yml
+++ b/config/install/islandora_mirador.settings.yml
@@ -1,4 +1,6 @@
 mirador_library_installation_type: 'remote'
-mirador_enabled_plugins: {  }
+mirador_enabled_plugins: 
+  - miradorImageToolsPlugin
+  - textOverlayPlugin
 iiif_manifest_url: '[node:url:unaliased:absolute]/manifest'
 mirador_library_minified: false

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -42,19 +42,29 @@ function template_preprocess_mirador(&$variables) {
   $config = \Drupal::service('config.factory')
     ->get('islandora_mirador.settings');
 
+  // Add config as cache dependency so changes invalidate the render cache.
+  $variables['#cache']['tags'][] = 'config:islandora_mirador.settings';
+
   $mirador_plugins = $mirador_plugin_manager->getDefinitions();
   $enabled_plugins = $config->get('mirador_enabled_plugins');
   $variables['#attached']['drupalSettings']['mirador']['enabled_plugins'] = array_filter(array_values($enabled_plugins));
 
   $window_config = $variables['window_config'];
   foreach ($mirador_plugins as $plugin_id => $plugin_definition) {
-    if (isset($enabled_plugins[$plugin_id])) {
-      $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
-      /**
-       * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
-       */
-      $plugin_instance->windowConfigAlter($window_config);
-    }
+    // if (isset($enabled_plugins[$plugin_id])) {
+    //   $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
+    //   /**
+    //    * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
+    //    */
+    //   $plugin_instance->windowConfigAlter($window_config);
+    // }
+
+    // Always call plugins - they will check their own state
+    $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
+    /**
+     * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
+     */
+    $plugin_instance->windowConfigAlter($window_config);
   }
 
   // XXX: Maintain the original properties, for now.

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -52,7 +52,7 @@ function template_preprocess_mirador(&$variables) {
   $window_config = $variables['window_config'];
   foreach ($mirador_plugins as $plugin_id => $plugin_definition) {
 
-    // Always call plugins - they will check their own state
+    // Always call plugins - they will check their own state.
     /**
      * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
      */

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -51,19 +51,12 @@ function template_preprocess_mirador(&$variables) {
 
   $window_config = $variables['window_config'];
   foreach ($mirador_plugins as $plugin_id => $plugin_definition) {
-    // if (isset($enabled_plugins[$plugin_id])) {
-    //   $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
-    //   /**
-    //    * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
-    //    */
-    //   $plugin_instance->windowConfigAlter($window_config);
-    // }
 
     // Always call plugins - they will check their own state
-    $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
     /**
      * @var Drupal\islandora_mirador\IslandoraMiradorPluginInterface
      */
+    $plugin_instance = $mirador_plugin_manager->createInstance($plugin_id);
     $plugin_instance->windowConfigAlter($window_config);
   }
 

--- a/islandora_mirador.post_update.php
+++ b/islandora_mirador.post_update.php
@@ -11,7 +11,7 @@
 function islandora_mirador_post_update_enable_plugins() {
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('islandora_mirador.settings');
-  
+
   // Get currently enabled plugins. Default to empty array.
   $enabled_plugins = $config->get('mirador_enabled_plugins');
   if (!is_array($enabled_plugins)) {

--- a/islandora_mirador.post_update.php
+++ b/islandora_mirador.post_update.php
@@ -23,8 +23,8 @@ function islandora_mirador_post_update_enable_plugins() {
   $changed = FALSE;
 
   foreach ($plugins_to_add as $plugin_id) {
-    if (!in_array($plugin_id, $enabled_plugins)) {
-      $enabled_plugins[] = $plugin_id;
+    if (empty($enabled_plugins[$plugin_id])) {
+      $enabled_plugins[$plugin_id] = $plugin_id;
       $changed = TRUE;
     }
   }

--- a/islandora_mirador.post_update.php
+++ b/islandora_mirador.post_update.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the module Islandora Mirador.
+ */
+
+/**
+ * Enable plugins by default for existing sites.
+ */
+function islandora_mirador_post_update_enable_plugins() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('islandora_mirador.settings');
+  
+  // Get currently enabled plugins. Default to empty array.
+  $enabled_plugins = $config->get('mirador_enabled_plugins');
+  if (!is_array($enabled_plugins)) {
+    $enabled_plugins = [];
+  }
+
+  // The array of plugins we want to be enabled.
+  $plugins_to_add = ['textOverlayPlugin', 'miradorImageToolsPlugin'];
+  $changed = FALSE;
+
+  foreach ($plugins_to_add as $plugin_id) {
+    if (!in_array($plugin_id, $enabled_plugins)) {
+      $enabled_plugins[] = $plugin_id;
+      $changed = TRUE;
+    }
+  }
+
+  if ($changed) {
+    $config->set('mirador_enabled_plugins', $enabled_plugins);
+    $config->save(TRUE);
+  }
+}

--- a/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
+++ b/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
@@ -19,8 +19,20 @@ class MiradorImageTools extends IslandoraMiradorPluginPluginBase {
    * {@inheritdoc}
    */
   public function windowConfigAlter(array &$windowConfig) {
-    $windowConfig['imageToolsEnabled'] = TRUE;
-    $windowConfig['imageToolsOpen'] = TRUE;
+    // Get the config to check if this plugin is enabled.
+    $config = \Drupal::service('config.factory')
+      ->get('islandora_mirador.settings');
+    $enabled_plugins = $config->get('mirador_enabled_plugins');
+    
+    if (!empty($enabled_plugins['miradorImageToolsPlugin'])) {
+      // Enabled config - checkbox is checked.
+      $windowConfig['imageToolsEnabled'] = true;
+      $windowConfig['imageToolsOpen'] = true;
+    } else {
+      // Disabled config - checkbox is unchecked.
+      $windowConfig['imageToolsEnabled'] = false;
+      $windowConfig['imageToolsOpen'] = false;
+    }
   }
 
 }

--- a/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
+++ b/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
@@ -54,21 +54,21 @@ class MiradorImageTools extends IslandoraMiradorPluginPluginBase implements Cont
   }
 
   /**
-   * {@InheritDoc}
+   * {@inheritdoc}
    */
   public function windowConfigAlter(array &$windowConfig) {
     // Get the config to check if this plugin is enabled.
     $config = $this->configFactory->get('islandora_mirador.settings');
     $enabled_plugins = $config->get('mirador_enabled_plugins');
-    
+
     if (!empty($enabled_plugins['miradorImageToolsPlugin'])) {
       // Enabled config - checkbox is checked.
-      $windowConfig['imageToolsEnabled'] = true;
-      $windowConfig['imageToolsOpen'] = true;
+      $windowConfig['imageToolsEnabled'] = TRUE;
+      $windowConfig['imageToolsOpen'] = TRUE;
     } else {
       // Disabled config - checkbox is unchecked.
-      $windowConfig['imageToolsEnabled'] = false;
-      $windowConfig['imageToolsOpen'] = false;
+      $windowConfig['imageToolsEnabled'] = FALSE;
+      $windowConfig['imageToolsOpen'] = FALSE;
     }
   }
 

--- a/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
+++ b/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
@@ -65,7 +65,8 @@ class MiradorImageTools extends IslandoraMiradorPluginPluginBase implements Cont
       // Enabled config - checkbox is checked.
       $windowConfig['imageToolsEnabled'] = TRUE;
       $windowConfig['imageToolsOpen'] = TRUE;
-    } else {
+    }
+    else {
       // Disabled config - checkbox is unchecked.
       $windowConfig['imageToolsEnabled'] = FALSE;
       $windowConfig['imageToolsOpen'] = FALSE;

--- a/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
+++ b/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
@@ -61,16 +61,9 @@ class MiradorImageTools extends IslandoraMiradorPluginPluginBase implements Cont
     $config = $this->configFactory->get('islandora_mirador.settings');
     $enabled_plugins = $config->get('mirador_enabled_plugins');
 
-    if (!empty($enabled_plugins['miradorImageToolsPlugin'])) {
-      // Enabled config - checkbox is checked.
-      $windowConfig['imageToolsEnabled'] = TRUE;
-      $windowConfig['imageToolsOpen'] = TRUE;
-    }
-    else {
-      // Disabled config - checkbox is unchecked.
-      $windowConfig['imageToolsEnabled'] = FALSE;
-      $windowConfig['imageToolsOpen'] = FALSE;
-    }
+    $enabled = !empty($enabled_plugins['miradorImageToolsPlugin']);
+    $windowConfig['imageToolsEnabled'] = $enabled;
+    $windowConfig['imageToolsOpen'] = $enabled;
   }
 
 }

--- a/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
+++ b/src/Plugin/IslandoraMiradorPlugin/MiradorImageTools.php
@@ -3,6 +3,9 @@
 namespace Drupal\islandora_mirador\Plugin\IslandoraMiradorPlugin;
 
 use Drupal\islandora_mirador\IslandoraMiradorPluginPluginBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the islandora_mirador.
@@ -13,15 +16,49 @@ use Drupal\islandora_mirador\IslandoraMiradorPluginPluginBase;
  *   description = @Translation("MIrador image manipluation..")
  * )
  */
-class MiradorImageTools extends IslandoraMiradorPluginPluginBase {
+class MiradorImageTools extends IslandoraMiradorPluginPluginBase implements ContainerFactoryPluginInterface {
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a TextOverlay object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configFactory = $config_factory;
+  }
 
   /**
    * {@inheritdoc}
    */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@InheritDoc}
+   */
   public function windowConfigAlter(array &$windowConfig) {
     // Get the config to check if this plugin is enabled.
-    $config = \Drupal::service('config.factory')
-      ->get('islandora_mirador.settings');
+    $config = $this->configFactory->get('islandora_mirador.settings');
     $enabled_plugins = $config->get('mirador_enabled_plugins');
     
     if (!empty($enabled_plugins['miradorImageToolsPlugin'])) {

--- a/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
+++ b/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
@@ -61,22 +61,13 @@ class TextOverlay extends IslandoraMiradorPluginPluginBase implements ContainerF
     $config = $this->configFactory->get('islandora_mirador.settings');
     $enabled_plugins = $config->get('mirador_enabled_plugins');
 
-    if (!empty($enabled_plugins['textOverlayPlugin'])) {
-      // Enabled config - checkbox is checked.
-      $windowConfig['textOverlay'] = [
-        "enabled" => TRUE,
-        "selectable" => TRUE,
-        "visible" => FALSE,
-      ];
-    }
-    else {
-      // Disabled config - checkbox is unchecked.
-      $windowConfig['textOverlay'] = [
-        "enabled" => FALSE,
-        "selectable" => FALSE,
-        "visible" => FALSE,
-      ];
-    }
+    // Enable config based on the checkbox.
+    $enabled = !empty($enabled_plugins['textOverlayPlugin']);
+    $windowConfig['textOverlay'] = [
+      "enabled" => $enabled,
+      "selectable" => $enabled,
+      "visible" => FALSE,
+    ];
   }
 
 }

--- a/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
+++ b/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
@@ -54,7 +54,7 @@ class TextOverlay extends IslandoraMiradorPluginPluginBase implements ContainerF
   }
 
   /**
-   * {@InheritDoc}
+   * {@inheritdoc}
    */
   public function windowConfigAlter(array &$windowConfig) {
     // Get the config to check if this plugin is enabled.
@@ -64,16 +64,17 @@ class TextOverlay extends IslandoraMiradorPluginPluginBase implements ContainerF
     if (!empty($enabled_plugins['textOverlayPlugin'])) {
       // Enabled config - checkbox is checked.
       $windowConfig['textOverlay'] = [
-        "enabled" => true,
-        "selectable" => true,
-        "visible" => false,
+        "enabled" => TRUE,
+        "selectable" => TRUE,
+        "visible" => FALSE,
       ];
-    } else {
+    } 
+    else {
       // Disabled config - checkbox is unchecked.
       $windowConfig['textOverlay'] = [
-        "enabled" => false,
-        "selectable" => false,
-        "visible" => false,
+        "enabled" => FALSE,
+        "selectable" => FALSE,
+        "visible" => FALSE,
       ];
     }
   }

--- a/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
+++ b/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
@@ -19,11 +19,26 @@ class TextOverlay extends IslandoraMiradorPluginPluginBase {
    * {@inheritdoc}
    */
   public function windowConfigAlter(array &$windowConfig) {
-    $windowConfig['textOverlay'] = [
-      "enabled" => TRUE,
-      "selectable" => TRUE,
-      "visible" => FALSE,
-    ];
+    // Get the config to check if this plugin is enabled.
+    $config = \Drupal::service('config.factory')
+      ->get('islandora_mirador.settings');
+    $enabled_plugins = $config->get('mirador_enabled_plugins');
+    
+    if (!empty($enabled_plugins['textOverlayPlugin'])) {
+      // Enabled config - checkbox is checked.
+      $windowConfig['textOverlay'] = [
+        "enabled" => true,
+        "selectable" => true,
+        "visible" => false,
+      ];
+    } else {
+      // Disabled config - checkbox is unchecked.
+      $windowConfig['textOverlay'] = [
+        "enabled" => false,
+        "selectable" => false,
+        "visible" => false,
+      ];
+    }
   }
 
 }

--- a/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
+++ b/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
@@ -3,6 +3,9 @@
 namespace Drupal\islandora_mirador\Plugin\IslandoraMiradorPlugin;
 
 use Drupal\islandora_mirador\IslandoraMiradorPluginPluginBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the islandora_mirador.
@@ -13,17 +16,51 @@ use Drupal\islandora_mirador\IslandoraMiradorPluginPluginBase;
  *   description = @Translation("Mirador text overlay plugin for text selection and accessibility.")
  * )
  */
-class TextOverlay extends IslandoraMiradorPluginPluginBase {
+class TextOverlay extends IslandoraMiradorPluginPluginBase implements ContainerFactoryPluginInterface {
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a TextOverlay object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configFactory = $config_factory;
+  }
 
   /**
    * {@inheritdoc}
    */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@InheritDoc}
+   */
   public function windowConfigAlter(array &$windowConfig) {
     // Get the config to check if this plugin is enabled.
-    $config = \Drupal::service('config.factory')
-      ->get('islandora_mirador.settings');
+    $config = $this->configFactory->get('islandora_mirador.settings');
     $enabled_plugins = $config->get('mirador_enabled_plugins');
-    
+
     if (!empty($enabled_plugins['textOverlayPlugin'])) {
       // Enabled config - checkbox is checked.
       $windowConfig['textOverlay'] = [

--- a/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
+++ b/src/Plugin/IslandoraMiradorPlugin/TextOverlay.php
@@ -68,7 +68,7 @@ class TextOverlay extends IslandoraMiradorPluginPluginBase implements ContainerF
         "selectable" => TRUE,
         "visible" => FALSE,
       ];
-    } 
+    }
     else {
       // Disabled config - checkbox is unchecked.
       $windowConfig['textOverlay'] = [

--- a/tests/src/Kernel/IslandoraMiradorPluginManagerTest.php
+++ b/tests/src/Kernel/IslandoraMiradorPluginManagerTest.php
@@ -31,6 +31,7 @@ class IslandoraMiradorPluginManagerTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->installConfig(['islandora_mirador']);
     $this->pluginManager = $this->container->get('plugin.manager.islandora_mirador');
   }
 


### PR DESCRIPTION
Closes Issue #59 
Closes and builds on top of PR #60 

# What does this Pull Request do?
This PR is a continuation of the work started by @DibyaGoswami in PR #60 to resolve Issue #59. 

# What's new?
**Original Logic:** Retains Dibya's fix to ensure the "Text Overlay" checkbox correctly affects the Mirador viewer.
**Changed Logic:** Utilizes Dependency Injection by replacing the ```\Drupal::service('config.factory')``` calls in **TextOverlay.php** and **MiradorImageTools.php**  as requested by @joecorall in the previous PR review.
