### PR TITLE
Allow changing the mirador theme and primary/secondary colors

### DIFF
--- a/config/install/islandora_mirador.settings.yml
+++ b/config/install/islandora_mirador.settings.yml
@@ -1,6 +1,11 @@
 mirador_library_installation_type: 'remote'
-mirador_enabled_plugins: 
+mirador_enabled_plugins:
   miradorImageToolsPlugin: miradorImageToolsPlugin
   textOverlayPlugin: textOverlayPlugin
 iiif_manifest_url: '[node:url:unaliased:absolute]/manifest'
 mirador_library_minified: false
+mirador_selected_theme: 'light'
+mirador_theme_light_primary: '#1967d2'
+mirador_theme_light_secondary: '#1967d2'
+mirador_theme_dark_primary: '#4db6ac'
+mirador_theme_dark_secondary: '#4db6ac'

--- a/config/schema/islandora_mirador.schema.yml
+++ b/config/schema/islandora_mirador.schema.yml
@@ -24,14 +24,14 @@ islandora_mirador.settings:
       type: string
       label: 'Selected Mirador theme'
     mirador_theme_light_primary:
-      type: string
+      type: color_hex
       label: 'Light theme primary color'
     mirador_theme_light_secondary:
-      type: string
+      type: color_hex
       label: 'Light theme secondary color'
     mirador_theme_dark_primary:
-      type: string
+      type: color_hex
       label: 'Dark theme primary color'
     mirador_theme_dark_secondary:
-      type: string
+      type: color_hex
       label: 'Dark theme secondary color'

--- a/config/schema/islandora_mirador.schema.yml
+++ b/config/schema/islandora_mirador.schema.yml
@@ -17,3 +17,18 @@ islandora_mirador.settings:
     mirador_library_minified:
       type: boolean
       label: 'Use minified Mirador library'
+    mirador_selected_theme:
+      type: string
+      label: 'Selected Mirador theme'
+    mirador_theme_light_primary:
+      type: string
+      label: 'Light theme primary color'
+    mirador_theme_light_secondary:
+      type: string
+      label: 'Light theme secondary color'
+    mirador_theme_dark_primary:
+      type: string
+      label: 'Dark theme primary color'
+    mirador_theme_dark_secondary:
+      type: string
+      label: 'Dark theme secondary color'

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -68,10 +68,35 @@ function template_preprocess_mirador(&$variables) {
   // mirador.window_settings ... isn't presently used on its own?
   $variables['#attached']['drupalSettings']['mirador']['window_settings'] = $window_config;
 
+  // Build theme configuration from settings.
+  $selected_theme = $config->get('mirador_selected_theme');
+  $theme_config = [];
+  $light_primary = $config->get('mirador_theme_light_primary');
+  $light_secondary = $config->get('mirador_theme_light_secondary');
+  $dark_primary = $config->get('mirador_theme_dark_primary');
+  $dark_secondary = $config->get('mirador_theme_dark_secondary');
+  if ($light_primary || $light_secondary) {
+    if ($light_primary) {
+      $theme_config['light']['palette']['primary']['main'] = $light_primary;
+    }
+    if ($light_secondary) {
+      $theme_config['light']['palette']['secondary']['main'] = $light_secondary;
+    }
+  }
+  if ($dark_primary || $dark_secondary) {
+    if ($dark_primary) {
+      $theme_config['dark']['palette']['primary']['main'] = $dark_primary;
+    }
+    if ($dark_secondary) {
+      $theme_config['dark']['palette']['secondary']['main'] = $dark_secondary;
+    }
+  }
+
   // mirador.viewers is an associative array mapping CSS/jQuery/once selectors
   // to objects of mirador configuration.
-  $variables['#attached']['drupalSettings']['mirador']['viewers']["#{$variables['mirador_view_id']}"] = [
+  $viewer_config = [
     'id' => $variables['mirador_view_id'],
+    'selectedTheme' => $selected_theme,
     'manifests' => [
       $variables['iiif_manifest_url'] => [
         'provider' => 'Islandora',
@@ -86,6 +111,10 @@ function template_preprocess_mirador(&$variables) {
     ],
     'workspace' => $variables['workspace_config'],
   ];
+  if (!empty($theme_config)) {
+    $viewer_config['themes'] = $theme_config;
+  }
+  $variables['#attached']['drupalSettings']['mirador']['viewers']["#{$variables['mirador_view_id']}"] = $viewer_config;
 }
 
 /**

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -81,21 +81,17 @@ function template_preprocess_mirador(&$variables) {
   $light_secondary = $config->get('mirador_theme_light_secondary');
   $dark_primary = $config->get('mirador_theme_dark_primary');
   $dark_secondary = $config->get('mirador_theme_dark_secondary');
-  if ($light_primary || $light_secondary) {
-    if ($light_primary) {
-      $theme_config['light']['palette']['primary']['main'] = $light_primary;
-    }
-    if ($light_secondary) {
-      $theme_config['light']['palette']['secondary']['main'] = $light_secondary;
-    }
+  if ($light_primary) {
+    $theme_config['light']['palette']['primary']['main'] = $light_primary;
   }
-  if ($dark_primary || $dark_secondary) {
-    if ($dark_primary) {
-      $theme_config['dark']['palette']['primary']['main'] = $dark_primary;
-    }
-    if ($dark_secondary) {
-      $theme_config['dark']['palette']['secondary']['main'] = $dark_secondary;
-    }
+  if ($light_secondary) {
+    $theme_config['light']['palette']['secondary']['main'] = $light_secondary;
+  }
+  if ($dark_primary) {
+    $theme_config['dark']['palette']['primary']['main'] = $dark_primary;
+  }
+  if ($dark_secondary) {
+    $theme_config['dark']['palette']['secondary']['main'] = $dark_secondary;
   }
 
   // mirador.viewers is an associative array mapping CSS/jQuery/once selectors

--- a/islandora_mirador.post_update.php
+++ b/islandora_mirador.post_update.php
@@ -34,3 +34,30 @@ function islandora_mirador_post_update_enable_plugins() {
     $config->save(TRUE);
   }
 }
+
+/**
+ * Set default theme settings for existing sites.
+ */
+function islandora_mirador_post_update_theme_defaults() {
+  $config = \Drupal::configFactory()->getEditable('islandora_mirador.settings');
+
+  $defaults = [
+    'mirador_selected_theme' => 'light',
+    'mirador_theme_light_primary' => '#1967d2',
+    'mirador_theme_light_secondary' => '#1967d2',
+    'mirador_theme_dark_primary' => '#4db6ac',
+    'mirador_theme_dark_secondary' => '#4db6ac',
+  ];
+
+  $changed = FALSE;
+  foreach ($defaults as $key => $value) {
+    if ($config->get($key) === NULL) {
+      $config->set($key, $value);
+      $changed = TRUE;
+    }
+  }
+
+  if ($changed) {
+    $config->save(TRUE);
+  }
+}

--- a/js/mirador_viewer.js
+++ b/js/mirador_viewer.js
@@ -16,11 +16,16 @@
             Drupal.IslandoraMirador.instances = Drupal.IslandoraMirador.instances || {}
             Object.entries(settings.mirador.viewers).forEach(entry => {
               const [base, values] = entry;
-              once('mirador-viewer', base, context).forEach(() =>
+              once('mirador-viewer', base, context).forEach(() => {
+                // Resolve 'system' theme to the OS preference at render time.
+                const resolvedValues = Object.assign({}, values);
+                if (resolvedValues.selectedTheme === 'system') {
+                    resolvedValues.selectedTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                }
                 // save the mirador instance so other modules can interact
                 // with the store/actions at e.g. Drupal.IslandoraMirador.instances["#mirador-xyz"].store
-                Drupal.IslandoraMirador.instances[base] = Mirador.viewer(values, window.miradorPlugins || {})
-              );
+                Drupal.IslandoraMirador.instances[base] = Mirador.viewer(resolvedValues, window.miradorPlugins || {});
+              });
             });
         },
         detach: function (context, settings) {

--- a/src/Form/MiradorConfigForm.php
+++ b/src/Form/MiradorConfigForm.php
@@ -92,33 +92,39 @@ class MiradorConfigForm extends ConfigFormBase {
       '#options' => [
         'light' => $this->t('Light'),
         'dark' => $this->t('Dark'),
+        'system' => $this->t("Use OS setting (follows the browser's light/dark preference)"),
       ],
       '#default_value' => $config->get('mirador_selected_theme'),
     ];
-    $form['mirador_theme_fieldset']['mirador_theme_light'] = [
+    $form['mirador_theme_fieldset']['mirador_theme_advanced'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Advanced theming'),
+      '#open' => FALSE,
+    ];
+    $form['mirador_theme_fieldset']['mirador_theme_advanced']['mirador_theme_light'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Light theme colors'),
     ];
-    $form['mirador_theme_fieldset']['mirador_theme_light']['mirador_theme_light_primary'] = [
+    $form['mirador_theme_fieldset']['mirador_theme_advanced']['mirador_theme_light']['mirador_theme_light_primary'] = [
       '#type' => 'color',
       '#title' => $this->t('Primary color'),
       '#default_value' => $config->get('mirador_theme_light_primary'),
     ];
-    $form['mirador_theme_fieldset']['mirador_theme_light']['mirador_theme_light_secondary'] = [
+    $form['mirador_theme_fieldset']['mirador_theme_advanced']['mirador_theme_light']['mirador_theme_light_secondary'] = [
       '#type' => 'color',
       '#title' => $this->t('Secondary color'),
       '#default_value' => $config->get('mirador_theme_light_secondary'),
     ];
-    $form['mirador_theme_fieldset']['mirador_theme_dark'] = [
+    $form['mirador_theme_fieldset']['mirador_theme_advanced']['mirador_theme_dark'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('Dark theme colors'),
     ];
-    $form['mirador_theme_fieldset']['mirador_theme_dark']['mirador_theme_dark_primary'] = [
+    $form['mirador_theme_fieldset']['mirador_theme_advanced']['mirador_theme_dark']['mirador_theme_dark_primary'] = [
       '#type' => 'color',
       '#title' => $this->t('Primary color'),
       '#default_value' => $config->get('mirador_theme_dark_primary'),
     ];
-    $form['mirador_theme_fieldset']['mirador_theme_dark']['mirador_theme_dark_secondary'] = [
+    $form['mirador_theme_fieldset']['mirador_theme_advanced']['mirador_theme_dark']['mirador_theme_dark_secondary'] = [
       '#type' => 'color',
       '#title' => $this->t('Secondary color'),
       '#default_value' => $config->get('mirador_theme_dark_secondary'),
@@ -154,8 +160,8 @@ class MiradorConfigForm extends ConfigFormBase {
     parent::validateForm($form, $form_state);
 
     $theme = $form_state->getValue('mirador_selected_theme');
-    if (!in_array($theme, ['light', 'dark'], TRUE)) {
-      $form_state->setErrorByName('mirador_selected_theme', $this->t('Theme must be either "light" or "dark".'));
+    if (!in_array($theme, ['light', 'dark', 'system'], TRUE)) {
+      $form_state->setErrorByName('mirador_selected_theme', $this->t('Theme must be "light", "dark", or "system".'));
     }
 
     $color_fields = [

--- a/src/Form/MiradorConfigForm.php
+++ b/src/Form/MiradorConfigForm.php
@@ -72,6 +72,51 @@ class MiradorConfigForm extends ConfigFormBase {
       '#options' => $plugins,
       '#default_value' => $config->get('mirador_enabled_plugins'),
     ];
+    $form['mirador_theme_fieldset'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Theme'),
+      '#description' => $this->t('Configure the Mirador viewer theme and color palette. See the <a href=":url">Mirador theming documentation</a> for more information.', [
+        ':url' => 'https://github.com/ProjectMirador/mirador/wiki/M3-Theming-Mirador',
+      ]),
+    ];
+    $form['mirador_theme_fieldset']['mirador_selected_theme'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Selected theme'),
+      '#options' => [
+        'light' => $this->t('Light'),
+        'dark' => $this->t('Dark'),
+      ],
+      '#default_value' => $config->get('mirador_selected_theme'),
+    ];
+    $form['mirador_theme_fieldset']['mirador_theme_light'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Light theme colors'),
+    ];
+    $form['mirador_theme_fieldset']['mirador_theme_light']['mirador_theme_light_primary'] = [
+      '#type' => 'color',
+      '#title' => $this->t('Primary color'),
+      '#default_value' => $config->get('mirador_theme_light_primary'),
+    ];
+    $form['mirador_theme_fieldset']['mirador_theme_light']['mirador_theme_light_secondary'] = [
+      '#type' => 'color',
+      '#title' => $this->t('Secondary color'),
+      '#default_value' => $config->get('mirador_theme_light_secondary'),
+    ];
+    $form['mirador_theme_fieldset']['mirador_theme_dark'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Dark theme colors'),
+    ];
+    $form['mirador_theme_fieldset']['mirador_theme_dark']['mirador_theme_dark_primary'] = [
+      '#type' => 'color',
+      '#title' => $this->t('Primary color'),
+      '#default_value' => $config->get('mirador_theme_dark_primary'),
+    ];
+    $form['mirador_theme_fieldset']['mirador_theme_dark']['mirador_theme_dark_secondary'] = [
+      '#type' => 'color',
+      '#title' => $this->t('Secondary color'),
+      '#default_value' => $config->get('mirador_theme_dark_secondary'),
+    ];
+
     $form['iiif_manifest_url_fieldset'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('IIIF Manifest URL'),
@@ -98,12 +143,42 @@ class MiradorConfigForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    $theme = $form_state->getValue('mirador_selected_theme');
+    if (!in_array($theme, ['light', 'dark'], TRUE)) {
+      $form_state->setErrorByName('mirador_selected_theme', $this->t('Theme must be either "light" or "dark".'));
+    }
+
+    $color_fields = [
+      'mirador_theme_light_primary',
+      'mirador_theme_light_secondary',
+      'mirador_theme_dark_primary',
+      'mirador_theme_dark_secondary',
+    ];
+    foreach ($color_fields as $field) {
+      $value = $form_state->getValue($field);
+      if ($value !== NULL && $value !== '' && !preg_match('/^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/', $value)) {
+        $form_state->setErrorByName($field, $this->t('Color must be a valid CSS hex color (e.g. #fff or #1967d2).'));
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $config = $this->config('islandora_mirador.settings');
     $config->set('mirador_library_installation_type', $form_state->getValue('mirador_library_installation_type'));
     $config->set('mirador_enabled_plugins', $form_state->getValue('mirador_enabled_plugins'));
     $config->set('iiif_manifest_url', $form_state->getValue('iiif_manifest_url'));
     $config->set('mirador_library_minified', $form_state->getValue('mirador_library_minified'));
+    $config->set('mirador_selected_theme', $form_state->getValue('mirador_selected_theme'));
+    $config->set('mirador_theme_light_primary', $form_state->getValue('mirador_theme_light_primary'));
+    $config->set('mirador_theme_light_secondary', $form_state->getValue('mirador_theme_light_secondary'));
+    $config->set('mirador_theme_dark_primary', $form_state->getValue('mirador_theme_dark_primary'));
+    $config->set('mirador_theme_dark_secondary', $form_state->getValue('mirador_theme_dark_secondary'));
     $config->save();
     parent::submitForm($form, $form_state);
   }

--- a/tests/src/Kernel/MiradorConfigFormTest.php
+++ b/tests/src/Kernel/MiradorConfigFormTest.php
@@ -49,7 +49,8 @@ class MiradorConfigFormTest extends KernelTestBase {
     $form_object = MiradorConfigForm::create($this->container);
     $form_state = new FormState();
     $form_state->setValues($values);
-    $form_object->validateForm([], $form_state);
+    $form = [];
+    $form_object->validateForm($form, $form_state);
     return $form_state;
   }
 
@@ -67,6 +68,16 @@ class MiradorConfigFormTest extends KernelTestBase {
   public function testValidDarkTheme(): void {
     $values = $this->validValues();
     $values['mirador_selected_theme'] = 'dark';
+    $form_state = $this->validateWithValues($values);
+    $this->assertFalse($form_state->hasAnyErrors());
+  }
+
+  /**
+   * Tests that the system theme option is valid.
+   */
+  public function testValidSystemTheme(): void {
+    $values = $this->validValues();
+    $values['mirador_selected_theme'] = 'system';
     $form_state = $this->validateWithValues($values);
     $this->assertFalse($form_state->hasAnyErrors());
   }

--- a/tests/src/Kernel/MiradorConfigFormTest.php
+++ b/tests/src/Kernel/MiradorConfigFormTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Drupal\Tests\islandora_mirador\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\islandora_mirador\Form\MiradorConfigForm;
+
+/**
+ * Tests the MiradorConfigForm validation.
+ *
+ * @group islandora_mirador
+ */
+class MiradorConfigFormTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'islandora_mirador',
+    'system',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['islandora_mirador']);
+  }
+
+  /**
+   * Returns a form object with valid base values for theme fields.
+   */
+  protected function validValues(): array {
+    return [
+      'mirador_selected_theme' => 'light',
+      'mirador_theme_light_primary' => '#1967d2',
+      'mirador_theme_light_secondary' => '#1967d2',
+      'mirador_theme_dark_primary' => '#4db6ac',
+      'mirador_theme_dark_secondary' => '#4db6ac',
+    ];
+  }
+
+  /**
+   * Runs validateForm on a MiradorConfigForm with the given values.
+   */
+  protected function validateWithValues(array $values): FormState {
+    $form_object = MiradorConfigForm::create($this->container);
+    $form_state = new FormState();
+    $form_state->setValues($values);
+    $form_object->validateForm([], $form_state);
+    return $form_state;
+  }
+
+  /**
+   * Tests that valid theme and colors pass validation.
+   */
+  public function testValidLightTheme(): void {
+    $form_state = $this->validateWithValues($this->validValues());
+    $this->assertFalse($form_state->hasAnyErrors());
+  }
+
+  /**
+   * Tests that dark theme is also valid.
+   */
+  public function testValidDarkTheme(): void {
+    $values = $this->validValues();
+    $values['mirador_selected_theme'] = 'dark';
+    $form_state = $this->validateWithValues($values);
+    $this->assertFalse($form_state->hasAnyErrors());
+  }
+
+  /**
+   * Tests that a 3-digit hex color is valid.
+   */
+  public function testValidShortHexColor(): void {
+    $values = $this->validValues();
+    $values['mirador_theme_light_primary'] = '#fff';
+    $form_state = $this->validateWithValues($values);
+    $this->assertFalse($form_state->hasAnyErrors());
+  }
+
+  /**
+   * Tests that an invalid theme value fails validation.
+   */
+  public function testInvalidTheme(): void {
+    $values = $this->validValues();
+    $values['mirador_selected_theme'] = 'blue';
+    $form_state = $this->validateWithValues($values);
+    $this->assertTrue($form_state->hasAnyErrors());
+    $errors = $form_state->getErrors();
+    $this->assertArrayHasKey('mirador_selected_theme', $errors);
+  }
+
+  /**
+   * Tests that a color without a leading # fails validation.
+   */
+  public function testInvalidColorMissingHash(): void {
+    $values = $this->validValues();
+    $values['mirador_theme_light_primary'] = '1967d2';
+    $form_state = $this->validateWithValues($values);
+    $this->assertTrue($form_state->hasAnyErrors());
+    $errors = $form_state->getErrors();
+    $this->assertArrayHasKey('mirador_theme_light_primary', $errors);
+  }
+
+  /**
+   * Tests that a color with invalid hex characters fails validation.
+   */
+  public function testInvalidColorBadCharacters(): void {
+    $values = $this->validValues();
+    $values['mirador_theme_dark_secondary'] = '#zzzzzz';
+    $form_state = $this->validateWithValues($values);
+    $this->assertTrue($form_state->hasAnyErrors());
+    $errors = $form_state->getErrors();
+    $this->assertArrayHasKey('mirador_theme_dark_secondary', $errors);
+  }
+
+  /**
+   * Tests that a color with wrong length fails validation.
+   */
+  public function testInvalidColorWrongLength(): void {
+    $values = $this->validValues();
+    $values['mirador_theme_dark_primary'] = '#12345';
+    $form_state = $this->validateWithValues($values);
+    $this->assertTrue($form_state->hasAnyErrors());
+    $errors = $form_state->getErrors();
+    $this->assertArrayHasKey('mirador_theme_dark_primary', $errors);
+  }
+
+  /**
+   * Tests that multiple invalid fields each produce their own error.
+   */
+  public function testMultipleInvalidFields(): void {
+    $values = $this->validValues();
+    $values['mirador_selected_theme'] = 'invalid';
+    $values['mirador_theme_light_secondary'] = 'notacolor';
+    $form_state = $this->validateWithValues($values);
+    $errors = $form_state->getErrors();
+    $this->assertArrayHasKey('mirador_selected_theme', $errors);
+    $this->assertArrayHasKey('mirador_theme_light_secondary', $errors);
+  }
+
+  /**
+   * Tests that config defaults are set correctly on fresh install.
+   */
+  public function testConfigDefaults(): void {
+    $config = $this->config('islandora_mirador.settings');
+    $this->assertEquals('light', $config->get('mirador_selected_theme'));
+    $this->assertEquals('#1967d2', $config->get('mirador_theme_light_primary'));
+    $this->assertEquals('#1967d2', $config->get('mirador_theme_light_secondary'));
+    $this->assertEquals('#4db6ac', $config->get('mirador_theme_dark_primary'));
+    $this->assertEquals('#4db6ac', $config->get('mirador_theme_dark_secondary'));
+  }
+
+}


### PR DESCRIPTION
# What does this Pull Request do?

Add options to the settings form to allow changing the theme on mirador to light, dark, or OS setting (default is light). Also allow setting primary/secondary colors.

[Demo of new settings and their effect](https://d.pr/i/TfpWHm)

* **Other Relevant Links**: https://islandora.slack.com/archives/C019U12D44Q/p1772054415983419

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora/committers
