### PR TITLE
Tooltips buried in Mirador viewer

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -2,3 +2,12 @@
   height: 1200px;
   position: relative;
 }
+/* Fixes for Tooltips is underneath parent frame */
+.mirador1 .MuiTooltip-popper {
+    z-index: 9999 !important;
+    left: 20px !important;
+}
+.mirador1 {
+    overflow: visible !important;
+}
+

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -118,6 +118,9 @@ function template_preprocess_mirador(&$variables) {
     $viewer_config['themes'] = $theme_config;
   }
   $variables['#attached']['drupalSettings']['mirador']['viewers']["#{$variables['mirador_view_id']}"] = $viewer_config;
+ 
+  // Attach the viewer libraries.
+  $variables['#attached']['library'][] = 'islandora_mirador/viewer';
 }
 
 /**

--- a/islandora_mirador.module
+++ b/islandora_mirador.module
@@ -118,7 +118,6 @@ function template_preprocess_mirador(&$variables) {
     $viewer_config['themes'] = $theme_config;
   }
   $variables['#attached']['drupalSettings']['mirador']['viewers']["#{$variables['mirador_view_id']}"] = $viewer_config;
- 
   // Attach the viewer libraries.
   $variables['#attached']['library'][] = 'islandora_mirador/viewer';
 }


### PR DESCRIPTION
# What does this Pull Request do?

Add CSS code to prevent the tooltips not to be displayed and got cut underneath the Mirador frame. 

* **Related GitHub Issue**: [(link)](https://github.com/Islandora/islandora_mirador/issues/65)

* **Other Relevant Links**: (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What's new?
Add some css to adjust the z-index of the Tooltips.

# How should this be tested?

* Apply the patch from this PR or the branch, 
* Open Mirador viewer page ie. https://sandbox.islandora.ca/islandora/excerpt-wild-flowers-western-canada
* Mouse over "Jump to window"  or  "Collapse Image Tool" button and verify the tooltips not got cut underneath the Mirador frame. 

<img width="226" height="195" alt="image" src="https://github.com/user-attachments/assets/6aa27b7f-a647-4d0c-ac5b-4ec69699388f" />

<img width="341" height="285" alt="image" src="https://github.com/user-attachments/assets/c07febd8-22e9-4505-8226-226d96c28dc0" />
