### PR TITLE
Add mobile responsive styles to mirador.css

### DIFF
--- a/css/mirador.css
+++ b/css/mirador.css
@@ -10,4 +10,29 @@
 .mirador1 {
     overflow: visible !important;
 }
-
+@media screen and (max-width: 768px) {
+  .block-mirador {
+    height: 100vh;
+    min-height: 400px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  /* Improve touch target sizes for mobile */
+  .mirador-container * {
+    touch-action: manipulation;
+  }
+  #mirador {
+    height: 100% !important;
+    width: 100% !important;
+    position: relative !important;
+  }
+  /* Ensure navigation and controls are accessible on touch devices */
+  .mirador-osd, .mirador-canvas {
+    min-height: 200px;
+    touch-action: pan-x pan-y pinch-zoom;
+  }
+  /* Fix for mobile browsers that may zoom in too much */
+  #mirador, #mirador * {
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
+  }  
+}


### PR DESCRIPTION
Added responsive styles for mobile devices to improve usability.

# What does this Pull Request do?

Provide a brief description of what the intended result of the PR will be and/or what
 problem it solves.

* **Related GitHub Issue**: https://github.com/Islandora/islandora_mirador/issues/67

## Changes
* **Optimized Mobile Height:** Adjusts the `.block-mirador` container to utilize more vertical screen real estate using `100dvh` (dynamic viewport height) to better account for mobile browser toolbars.
* **Touch Optimization:** Implements `touch-action: manipulation` and specific pan/zoom settings for the OpenSeadragon canvas to prevent accidental zooming of the whole page.
* **UX Improvements:** Removes the default WebKit tap highlight and ensures the viewer container fills its parent appropriately.

## Proposed CSS
```css
@media screen and (max-width: 768px) {
  .block-mirador {
    /* Uses dynamic viewport height to fit mobile screens better */
    height: 100dvh;
    min-height: 400px;
    overflow-y: auto;
    -webkit-overflow-scrolling: touch;
  }

  /* Improve touch target interaction */
  .mirador-container * {
    touch-action: manipulation;
  }

  #mirador {
    height: 100% !important;
    width: 100% !important;
    position: relative !important;
  }

  /* Ensure navigation and controls are accessible on touch devices */
  .mirador-osd, 
  .mirador-canvas {
    min-height: 200px;
    touch-action: pan-x pan-y pinch-zoom;
  }

  /* Fix for mobile browsers that may zoom in too much or show tap overlays */
  #mirador, 
  #mirador * {
    -webkit-tap-highlight-color: transparent;
  }  
}
````
Before look: 
<img width="636" height="987" alt="Image" src="https://github.com/user-attachments/assets/7c35ef85-b8db-47ef-b9ff-349fbe7742df" />

After look: 
<img width="483" height="978" alt="Image" src="https://github.com/user-attachments/assets/7c2a75e0-6f25-41ac-b8ae-69255762e275" />

